### PR TITLE
Create static mental health portal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run tests
+        run: |
+          node tests/score.test.js
+      - name: Copy files
+        run: |
+          mkdir public
+          cp -r index.html styles.css src public/
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# portal-emocional-web
+# Portal Emocional Web
+
+Este projeto é um portal estático para aplicação de questionários de saúde mental **PHQ-9**, **GAD-7** e **DASS-21**. O site pode ser hospedado no GitHub Pages e utiliza apenas HTML, CSS e JavaScript.
+
+## Desenvolvimento
+
+1. Clone o repositório e abra os arquivos `index.html`, `src/app.js` e `src/score.js` para ajustes.
+2. Para rodar os testes das funções de cálculo execute:
+
+```bash
+node tests/score.test.js
+```
+
+## Deploy no GitHub Pages
+
+O workflow `deploy.yml` gera o artefato estático e publica em GitHub Pages a cada push na branch `main`.
+
+## Questionários
+
+Os questionários seguem as versões oficiais e o cálculo de pontuação está implementado em `src/score.js`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Portal Emocional</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Portal Emocional</h1>
+  </header>
+  <main id="app">
+    <section id="consent-section" class="modal hidden">
+      <div class="modal-content">
+        <h2>Consentimento Informado</h2>
+        <p>Ao prosseguir, você concorda com a coleta anônima de suas respostas para fins de pesquisa e melhoria deste portal.</p>
+        <button id="accept-consent">Concordo</button>
+      </div>
+    </section>
+    <section id="home">
+      <h2>Escolha um Questionário</h2>
+      <div class="card-container">
+        <div class="card" data-test="phq9">
+          <h3>PHQ-9</h3>
+          <p>Avaliação de sintomas depressivos.</p>
+          <button>Iniciar</button>
+        </div>
+        <div class="card" data-test="gad7">
+          <h3>GAD-7</h3>
+          <p>Avaliação de ansiedade generalizada.</p>
+          <button>Iniciar</button>
+        </div>
+        <div class="card" data-test="dass21">
+          <h3>DASS-21</h3>
+          <p>Avaliação de depressão, ansiedade e estresse.</p>
+          <button>Iniciar</button>
+        </div>
+      </div>
+    </section>
+    <section id="questionnaire" class="hidden">
+      <div id="question-container"></div>
+      <div class="controls">
+        <button id="prev">Anterior</button>
+        <button id="next">Próximo</button>
+      </div>
+    </section>
+    <section id="result" class="hidden">
+      <h2>Resultado</h2>
+      <div id="score"></div>
+      <canvas id="chart" width="400" height="200"></canvas>
+      <button id="download-pdf">Exportar PDF</button>
+    </section>
+  </main>
+  <script src="src/app.js"></script>
+</body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,180 @@
+import { scorePHQ9, scoreGAD7, scoreDASS21 } from './score.js';
+
+const tests = {
+  phq9: {
+    title: 'PHQ-9',
+    questions: [
+      'Pouco interesse ou prazer em fazer as coisas',
+      'Sentir-se para baixo, deprimido ou sem perspectiva',
+      'Dificuldade para pegar no sono ou permanecer dormindo, ou dormir em excesso',
+      'Sentir-se cansado ou com pouca energia',
+      'Falta de apetite ou comer demais',
+      'Sentir-se mal consigo mesmo, sentir que é um fracasso ou que decepcionou sua família',
+      'Dificuldade de concentração nas coisas, como ler o jornal ou ver televisão',
+      'Mover-se ou falar tão devagar que as outras pessoas poderiam ter notado? Ou o oposto, ficando agitado ou inquieto mais que o habitual',
+      'Pensamentos de que seria melhor estar morto ou se cortar de alguma forma'
+    ],
+    options: ['Nunca', 'Vários dias', 'Mais da metade dos dias', 'Quase todos os dias'],
+    scorer: scorePHQ9
+  },
+  gad7: {
+    title: 'GAD-7',
+    questions: [
+      'Sentir-se nervoso, ansioso ou no limite',
+      'Não conseguir parar ou controlar a preocupação',
+      'Preocupar-se demais com diferentes coisas',
+      'Dificuldade para relaxar',
+      'Ficar tão inquieto que é difícil ficar parado',
+      'Facilmente ficar irritado ou aborrecido',
+      'Sentir medo como se algo terrível pudesse acontecer'
+    ],
+    options: ['Nenhuma vez', 'Vários dias', 'Mais da metade dos dias', 'Quase todos os dias'],
+    scorer: scoreGAD7
+  },
+  dass21: {
+    title: 'DASS-21',
+    questions: [
+      'Me senti deprimido(a), melancólico(a) ou sem esperança',
+      'Senti boca seca',
+      'Não consegui vivenciar nenhum sentimento positivo',
+      'Senti que estava respirando de forma ofegante (dificuldade para respirar, mesmo sem esforço físico)',
+      'Tive dificuldade em "relaxar"',
+      'Não consegui, de maneira alguma, ter iniciativa para fazer as coisas',
+      'Tive tendência a reagir emocionalmente a situações',
+      'Senti tremores (por exemplo, nas mãos)',
+      'Senti que estava utilizando muita energia nervosa',
+      'Me senti preocupado(a) com situações em que poderia entrar em pânico e passar vergonha',
+      'Senti que não tinha nada a que ansiar',
+      'Senti-me agitado(a)',
+      'Achei difícil relaxar',
+      'Me senti deprimido e sem ânimo',
+      'Fui intolerante com tudo que me impedia de continuar o que eu estava fazendo',
+      'Senti que estava perto de entrar em pânico',
+      'Não consegui me entusiasmar com nada',
+      'Senti que não tinha valor nenhum como pessoa',
+      'Senti que estava irritado(a)',
+      'Senti tremores',
+      'Senti que a vida não tinha sentido'
+    ],
+    options: ['Nunca', 'Às vezes', 'Com frequência', 'Quase sempre'],
+    scorer: scoreDASS21
+  }
+};
+
+let currentTest = null;
+let currentQuestion = 0;
+let answers = [];
+
+const home = document.getElementById('home');
+const questionSection = document.getElementById('questionnaire');
+const questionContainer = document.getElementById('question-container');
+const resultSection = document.getElementById('result');
+const scoreDiv = document.getElementById('score');
+const chartCanvas = document.getElementById('chart');
+
+function showConsent() {
+  const consentSection = document.getElementById('consent-section');
+  if (!localStorage.getItem('consent')) {
+    consentSection.classList.remove('hidden');
+    document.getElementById('accept-consent').onclick = () => {
+      localStorage.setItem('consent', 'true');
+      consentSection.classList.add('hidden');
+    };
+  }
+}
+
+function startTest(key) {
+  currentTest = tests[key];
+  currentQuestion = 0;
+  answers = JSON.parse(localStorage.getItem(key + '-answers') || '[]');
+  home.classList.add('hidden');
+  questionSection.classList.remove('hidden');
+  renderQuestion();
+}
+
+function renderQuestion() {
+  const q = currentTest.questions[currentQuestion];
+  const opts = currentTest.options
+    .map((o, i) => `<label><input type="radio" name="answer" value="${i}" ${answers[currentQuestion]==i?'checked':''}/> ${o}</label>`)
+    .join('<br>');
+  questionContainer.innerHTML = `<h3>${q}</h3>${opts}`;
+  document.getElementById('prev').style.display = currentQuestion === 0 ? 'none' : 'inline-block';
+  document.getElementById('next').textContent = currentQuestion === currentTest.questions.length -1 ? 'Finalizar' : 'Próximo';
+}
+
+function saveAnswer() {
+  const selected = questionContainer.querySelector('input[name="answer"]:checked');
+  if (!selected) return false;
+  answers[currentQuestion] = Number(selected.value);
+  localStorage.setItem(currentTest.title + '-answers', JSON.stringify(answers));
+  return true;
+}
+
+function showResult() {
+  questionSection.classList.add('hidden');
+  resultSection.classList.remove('hidden');
+  let result = currentTest.scorer(answers);
+  if (currentTest === tests.dass21) {
+    scoreDiv.innerHTML = `Depressão: ${result.depression.score} (${result.depression.level})<br>`+
+    `Ansiedade: ${result.anxiety.score} (${result.anxiety.level})<br>`+
+    `Estresse: ${result.stress.score} (${result.stress.level})`;
+    new Chart(chartCanvas, {
+      type: 'bar',
+      data: {
+        labels: ['Depressão','Ansiedade','Estresse'],
+        datasets: [{
+          label: 'Pontuação',
+          data: [result.depression.score, result.anxiety.score, result.stress.score],
+          backgroundColor: ['#f87171','#60a5fa','#34d399']
+        }]
+      }
+    });
+  } else {
+    scoreDiv.textContent = `Pontuação: ${result.total} (${result.level})`;
+    new Chart(chartCanvas, {
+      type: 'bar',
+      data: {
+        labels: [currentTest.title],
+        datasets: [{
+          label: 'Pontuação',
+          data: [result.total],
+          backgroundColor: ['#60a5fa']
+        }]
+      }
+    });
+  }
+}
+
+function downloadPDF() {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF();
+  doc.text(scoreDiv.innerText, 10, 10);
+  doc.save('resultado.pdf');
+}
+
+document.querySelectorAll('.card').forEach(card => {
+  card.querySelector('button').onclick = () => startTest(card.dataset.test);
+});
+
+document.getElementById('prev').onclick = () => {
+  if (currentQuestion > 0) {
+    if (saveAnswer()) {
+      currentQuestion--;
+      renderQuestion();
+    }
+  }
+};
+
+document.getElementById('next').onclick = () => {
+  if (!saveAnswer()) return;
+  if (currentQuestion < currentTest.questions.length -1) {
+    currentQuestion++;
+    renderQuestion();
+  } else {
+    showResult();
+  }
+};
+
+document.getElementById('download-pdf').onclick = downloadPDF;
+
+showConsent();

--- a/src/score.js
+++ b/src/score.js
@@ -1,0 +1,46 @@
+export function scorePHQ9(answers) {
+  const total = answers.reduce((a, b) => a + b, 0);
+  let level = '';
+  if (total <= 4) level = 'Mínimo';
+  else if (total <= 9) level = 'Leve';
+  else if (total <= 14) level = 'Moderado';
+  else if (total <= 19) level = 'Moderadamente grave';
+  else level = 'Grave';
+  return { total, level };
+}
+
+export function scoreGAD7(answers) {
+  const total = answers.reduce((a, b) => a + b, 0);
+  let level = '';
+  if (total <= 4) level = 'Mínimo';
+  else if (total <= 9) level = 'Leve';
+  else if (total <= 14) level = 'Moderado';
+  else level = 'Grave';
+  return { total, level };
+}
+
+export function scoreDASS21(answers) {
+  const depressionIdx = [0,3,6,9,12,15,18];
+  const anxietyIdx = [1,4,7,10,13,16,19];
+  const stressIdx = [2,5,8,11,14,17,20];
+  const sum = idxs => idxs.reduce((t,i)=>t+answers[i],0)*2;
+  const depression = sum(depressionIdx);
+  const anxiety = sum(anxietyIdx);
+  const stress = sum(stressIdx);
+  const classify = (val, scale) => {
+    const table = {
+      depression: [0,10,14,21,28],
+      anxiety: [0,8,10,15,20],
+      stress: [0,15,19,26,34]
+    }[scale];
+    const labels = ['Normal','Leve','Moderado','Severo','Extremamente Severo'];
+    let i = table.findIndex(th => val < th);
+    if (i === -1) i = labels.length - 1;
+    return labels[i];
+  };
+  return {
+    depression: { score: depression, level: classify(depression,'depression') },
+    anxiety: { score: anxiety, level: classify(anxiety,'anxiety') },
+    stress: { score: stress, level: classify(stress,'stress') }
+  };
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,43 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+header {
+  background-color: #3f51b5;
+  color: white;
+  padding: 1rem;
+  text-align: center;
+}
+.card-container {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 2rem;
+}
+.card {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  width: 200px;
+  text-align: center;
+}
+.hidden { display: none; }
+.modal {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-content {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 4px;
+}
+.controls {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: space-between;
+}

--- a/tests/score.test.js
+++ b/tests/score.test.js
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { scorePHQ9, scoreGAD7, scoreDASS21 } from '../src/score.js';
+
+// PHQ-9 example answers all 2 -> total 18 -> Moderadamente grave
+const phq9 = Array(9).fill(2);
+const r1 = scorePHQ9(phq9);
+assert.strictEqual(r1.total, 18);
+assert.strictEqual(r1.level, 'Moderadamente grave');
+
+// GAD-7 all 1 -> total 7 -> Leve
+const gad7 = Array(7).fill(1);
+const r2 = scoreGAD7(gad7);
+assert.strictEqual(r2.total, 7);
+assert.strictEqual(r2.level, 'Leve');
+
+// DASS-21 all 2 -> each subscale sum = 14 -> score*2 = 28 -> Severe/extreme
+const dass21 = Array(21).fill(2);
+const r3 = scoreDASS21(dass21);
+assert.strictEqual(r3.depression.score, 28);
+assert.strictEqual(r3.depression.level, 'Extremamente Severo');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add HTML/CSS/JS portal with PHQ‑9, GAD‑7 and DASS‑21
- implement scoring logic and tests
- document usage and GitHub Pages deploy workflow

## Testing
- `node tests/score.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6872d89280b08332919c4ddb1b691a71

## Summary by Sourcery

Create a static mental health portal featuring PHQ-9, GAD-7, and DASS-21 questionnaires with full UI, scoring, visualization, and automated deployment.

New Features:
- Add questionnaire selection, navigation, and result display UI using HTML, CSS, and JavaScript
- Implement scoring logic for PHQ-9, GAD-7, and DASS-21 with classification levels
- Integrate Chart.js for visualizing scores and enable PDF export of results

CI:
- Configure GitHub Actions to run tests and deploy the site to GitHub Pages on main branch

Documentation:
- Revise README with Portuguese project overview, development steps, testing instructions, and deploy workflow

Tests:
- Add unit tests for scoring functions to validate total scores and severity levels