### PR TITLE
Fix consent modal script loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,6 @@
       <button id="download-pdf">Exportar PDF</button>
     </section>
   </main>
-  <script src="src/app.js"></script>
+  <script type="module" src="src/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `src/app.js` as an ES module so the consent modal works in the browser

## Testing
- `node tests/score.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6872dac0a3cc8332b76bcd1f4d08165c

## Summary by Sourcery

Bug Fixes:
- Convert the script tag in index.html to use type="module" for src/app.js