### PR TITLE
Fix DASS-21 classification and extend coverage

### DIFF
--- a/src/score.js
+++ b/src/score.js
@@ -29,12 +29,12 @@ export function scoreDASS21(answers) {
   const stress = sum(stressIdx);
   const classify = (val, scale) => {
     const table = {
-      depression: [0,10,14,21,28],
-      anxiety: [0,8,10,15,20],
-      stress: [0,15,19,26,34]
+      depression: [9, 13, 20, 27],
+      anxiety: [7, 9, 14, 19],
+      stress: [14, 18, 25, 33]
     }[scale];
-    const labels = ['Normal','Leve','Moderado','Severo','Extremamente Severo'];
-    let i = table.findIndex(th => val < th);
+    const labels = ['Normal', 'Leve', 'Moderado', 'Severo', 'Extremamente Severo'];
+    let i = table.findIndex(th => val <= th);
     if (i === -1) i = labels.length - 1;
     return labels[i];
   };

--- a/tests/score.test.js
+++ b/tests/score.test.js
@@ -13,10 +13,41 @@ const r2 = scoreGAD7(gad7);
 assert.strictEqual(r2.total, 7);
 assert.strictEqual(r2.level, 'Leve');
 
-// DASS-21 all 2 -> each subscale sum = 14 -> score*2 = 28 -> Severe/extreme
-const dass21 = Array(21).fill(2);
-const r3 = scoreDASS21(dass21);
-assert.strictEqual(r3.depression.score, 28);
-assert.strictEqual(r3.depression.level, 'Extremamente Severo');
+// DASS-21 severity bands for depression
+const depIdx = [0,3,6,9,12,15,18];
+
+// Normal (score 0)
+let a = Array(21).fill(0);
+let r = scoreDASS21(a);
+assert.strictEqual(r.depression.score, 0);
+assert.strictEqual(r.depression.level, 'Normal');
+
+// Leve (score 10)
+a = Array(21).fill(0);
+depIdx.slice(0,5).forEach(i => { a[i] = 1; });
+r = scoreDASS21(a);
+assert.strictEqual(r.depression.score, 10);
+assert.strictEqual(r.depression.level, 'Leve');
+
+// Moderado (score 14)
+a = Array(21).fill(0);
+depIdx.forEach(i => { a[i] = 1; });
+r = scoreDASS21(a);
+assert.strictEqual(r.depression.score, 14);
+assert.strictEqual(r.depression.level, 'Moderado');
+
+// Severo (score 22)
+a = Array(21).fill(0);
+[0,3,6,9,12].forEach(i => { a[i] = 2; });
+a[15] = 1;
+r = scoreDASS21(a);
+assert.strictEqual(r.depression.score, 22);
+assert.strictEqual(r.depression.level, 'Severo');
+
+// Extremamente Severo (score 28)
+a = Array(21).fill(2);
+r = scoreDASS21(a);
+assert.strictEqual(r.depression.score, 28);
+assert.strictEqual(r.depression.level, 'Extremamente Severo');
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- fix DASS‑21 helper logic to use inclusive ranges
- add tests for all DASS‑21 severity bands

## Testing
- `node tests/score.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6872e13a2f888332bf871c0d97d2da36

## Summary by Sourcery

Fix DASS-21 severity classification to use inclusive thresholds and expand unit tests to cover all depression severity levels

Bug Fixes:
- Fix DASS-21 classification logic to use inclusive range comparisons

Enhancements:
- Adjust severity threshold tables for depression, anxiety, and stress subscales

Tests:
- Add tests covering all DASS-21 depression severity bands