### PR TITLE
Implement answer persistence in questionnaire

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -81,8 +81,12 @@ const downloadBtn = document.getElementById('download-pdf');
 
 function renderQuestion() {
   const q = currentTest.questions[currentQuestion];
+  const currentAnswer = answers[currentQuestion];
   const opts = currentTest.options
-    .map((o, i) => `<label><input type="radio" name="answer" value="${i}"> ${o}</label>`)
+    .map((o, i) => {
+      const checked = currentAnswer === i ? 'checked' : '';
+      return `<label><input type="radio" name="answer" value="${i}" ${checked}> ${o}</label>`;
+    })
     .join('<br/>');
   questionContainer.innerHTML = `
     <h3>${q}</h3>


### PR DESCRIPTION
## Summary
- when rendering a question, show previously selected option

## Testing
- `node tests/score.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6872e13ea5e08332a068161c79a278b8

## Summary by Sourcery

Enhancements:
- Show saved answer choices when rendering questions to preserve user selections