### PR TITLE
Move consent modal logic to app.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,27 +55,7 @@
     </section>
   </main>
 
-  <!-- Script de Consentimento Informado isolado -->
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const consentSection = document.getElementById('consent-section');
-      const acceptBtn = document.getElementById('accept-consent');
-
-      // Exibe o modal se ainda não consentiu
-      if (!localStorage.getItem('consent')) {
-        consentSection.classList.remove('hidden');
-      }
-
-      // Fecha ao clicar em Concordo
-      acceptBtn.addEventListener('click', () => {
-        console.log('Botão Concordo clicado');
-        localStorage.setItem('consent', 'true');
-        consentSection.classList.add('hidden');
-      });
-    });
-  </script>
-
-  <!-- Script principal do app -->
-  <script type="module" src="src/app.js"></script>
-</body>
+    <!-- Script principal do app -->
+    <script type="module" src="src/app.js"></script>
+  </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -148,8 +148,7 @@ function startTest(key) {
   renderQuestion();
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  // Consentimento
+function initConsent() {
   const acceptBtn = document.getElementById('accept-consent');
   if (!localStorage.getItem('consent')) {
     consentSection.classList.remove('hidden');
@@ -158,6 +157,11 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem('consent', 'true');
     consentSection.classList.add('hidden');
   });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Consentimento
+  initConsent();
 
   // Iniciar testes pelos cards
   document.querySelectorAll('.card').forEach(card => {


### PR DESCRIPTION
## Summary
- consolidate consent functionality into `src/app.js`
- remove inline consent script from `index.html`

## Testing
- `node tests/score.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6872e143f0d08332a3bb69dbe4986667

## Summary by Sourcery

Extract consent modal logic from index.html into app.js by introducing an initConsent function and removing the inline script.

Enhancements:
- Introduce initConsent function in app.js to handle consent modal display and acceptance
- Invoke initConsent during the DOMContentLoaded event alongside existing card test initialization

Chores:
- Remove inline consent script from index.html, leaving only the main app.js script include