### PR TITLE
Add boundary score tests

### DIFF
--- a/tests/score.test.js
+++ b/tests/score.test.js
@@ -7,16 +7,115 @@ const r1 = scorePHQ9(phq9);
 assert.strictEqual(r1.total, 18);
 assert.strictEqual(r1.level, 'Moderadamente grave');
 
+// PHQ-9 boundary and low-score cases
+const phq9Low = Array(9).fill(0);
+let r = scorePHQ9(phq9Low);
+assert.strictEqual(r.total, 0);
+assert.strictEqual(r.level, 'Mínimo');
+
+r = scorePHQ9([1,1,1,1,0,0,0,0,0]); // total 4
+assert.strictEqual(r.total, 4);
+assert.strictEqual(r.level, 'Mínimo');
+
+r = scorePHQ9([1,1,1,1,1,0,0,0,0]); // total 5
+assert.strictEqual(r.total, 5);
+assert.strictEqual(r.level, 'Leve');
+
+r = scorePHQ9(Array(9).fill(1)); // total 9
+assert.strictEqual(r.total, 9);
+assert.strictEqual(r.level, 'Leve');
+
+r = scorePHQ9([2,2,2,2,2,0,0,0,0]); // total 10
+assert.strictEqual(r.total, 10);
+assert.strictEqual(r.level, 'Moderado');
+
+r = scorePHQ9([2,2,2,2,2,2,2,0,0]); // total 14
+assert.strictEqual(r.total, 14);
+assert.strictEqual(r.level, 'Moderado');
+
+r = scorePHQ9([3,3,3,3,3,0,0,0,0]); // total 15
+assert.strictEqual(r.total, 15);
+assert.strictEqual(r.level, 'Moderadamente grave');
+
+r = scorePHQ9([3,3,3,3,3,3,1,0,0]); // total 19
+assert.strictEqual(r.total, 19);
+assert.strictEqual(r.level, 'Moderadamente grave');
+
+r = scorePHQ9([3,3,3,3,3,3,2,0,0]); // total 20
+assert.strictEqual(r.total, 20);
+assert.strictEqual(r.level, 'Grave');
+
 // GAD-7 all 1 -> total 7 -> Leve
 const gad7 = Array(7).fill(1);
 const r2 = scoreGAD7(gad7);
 assert.strictEqual(r2.total, 7);
 assert.strictEqual(r2.level, 'Leve');
 
+// GAD-7 boundary and low-score cases
+const gad7Low = Array(7).fill(0);
+r = scoreGAD7(gad7Low);
+assert.strictEqual(r.total, 0);
+assert.strictEqual(r.level, 'Mínimo');
+
+r = scoreGAD7([1,1,1,1,0,0,0]); // total 4
+assert.strictEqual(r.total, 4);
+assert.strictEqual(r.level, 'Mínimo');
+
+r = scoreGAD7([1,1,1,1,1,0,0]); // total 5
+assert.strictEqual(r.total, 5);
+assert.strictEqual(r.level, 'Leve');
+
+r = scoreGAD7(Array(7).fill(1)); // total 7
+assert.strictEqual(r.total, 7);
+assert.strictEqual(r.level, 'Leve');
+
+r = scoreGAD7([2,2,2,2,2,0,0]); // total 10
+assert.strictEqual(r.total, 10);
+assert.strictEqual(r.level, 'Moderado');
+
+r = scoreGAD7([2,2,2,2,2,1,1]); // total 12
+assert.strictEqual(r.total, 12);
+assert.strictEqual(r.level, 'Moderado');
+
+r = scoreGAD7([3,3,3,3,3,0,0]); // total 15
+assert.strictEqual(r.total, 15);
+assert.strictEqual(r.level, 'Grave');
+
 // DASS-21 all 2 -> each subscale sum = 14 -> score*2 = 28 -> Severe/extreme
 const dass21 = Array(21).fill(2);
 const r3 = scoreDASS21(dass21);
 assert.strictEqual(r3.depression.score, 28);
 assert.strictEqual(r3.depression.level, 'Extremamente Severo');
+
+// DASS-21 boundary and low-score cases
+const dassLow = Array(21).fill(0);
+let rd = scoreDASS21(dassLow);
+assert.strictEqual(rd.depression.score, 0);
+assert.strictEqual(rd.depression.level, 'Leve');
+assert.strictEqual(rd.anxiety.score, 0);
+assert.strictEqual(rd.anxiety.level, 'Leve');
+assert.strictEqual(rd.stress.score, 0);
+assert.strictEqual(rd.stress.level, 'Leve');
+
+// Depression score 10 -> Moderado
+rd = scoreDASS21([
+ 1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,0,0,0,0
+]);
+assert.strictEqual(rd.depression.score, 10);
+assert.strictEqual(rd.depression.level, 'Moderado');
+
+// Anxiety score 8 -> Moderado
+rd = scoreDASS21([
+ 0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0
+]);
+assert.strictEqual(rd.anxiety.score, 8);
+assert.strictEqual(rd.anxiety.level, 'Moderado');
+
+// Stress score 16 -> Moderado
+rd = scoreDASS21([
+ 0,0,2,0,0,2,0,0,2,0,0,2,0,0,0,0,0,0,0,0,0
+]);
+assert.strictEqual(rd.stress.score, 16);
+assert.strictEqual(rd.stress.level, 'Moderado');
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- expand score.test.js with low and boundary cases for PHQ‑9, GAD‑7 and DASS‑21

## Testing
- `node tests/score.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6872e14a87348332be6a1b175df882c2

## Summary by Sourcery

Add comprehensive low-score and boundary test cases for PHQ-9, GAD-7, and DASS-21 scoring functions

Tests:
- Add PHQ-9 boundary and low-score assertions across all severity thresholds
- Add GAD-7 boundary and low-score assertions across all severity thresholds
- Add DASS-21 boundary and low-score assertions for depression, anxiety, and stress subscales